### PR TITLE
Adding support for a fixed primary

### DIFF
--- a/cmd/litefs/main.go
+++ b/cmd/litefs/main.go
@@ -188,17 +188,17 @@ func (m *Main) Run(ctx context.Context) (err error) {
 
     // Use Consul?
 	if m.Config.Consul.URL != "" {
-    	log.Println("Using Consul to determine primary")
-    	// key must be set
-    	if m.Config.Consul.Key == "" {
-    		return fmt.Errorf("consul.key required")
-    	}
-    	if err := m.initConsul(ctx); err != nil {
-    		return fmt.Errorf("cannot init consul: %w", err)
-    	}
+        log.Println("Using Consul to determine primary")
+        // key must be set
+        if m.Config.Consul.Key == "" {
+            return fmt.Errorf("consul.key required")
+        }
+        if err := m.initConsul(ctx); err != nil {
+            return fmt.Errorf("cannot init consul: %w", err)
+        }
 	} else if m.Config.PrimaryURL != "" {
-    	log.Println("Using FixedPrimary to determine primary")
-    	m.Leaser = fixedprimary.NewLeaser(m.Config.PrimaryURL, m.Store.ID())
+        log.Println("Using FixedPrimary to determine primary")
+        m.Leaser = fixedprimary.NewLeaser(m.Config.PrimaryURL, m.Store.ID())
 	}
 
 	if err := m.openStore(ctx); err != nil {

--- a/fixedprimary/fixedprimary.go
+++ b/fixedprimary/fixedprimary.go
@@ -1,0 +1,89 @@
+package fixedprimary
+
+import (
+	"context"
+	"time"
+	"math"
+	"log"
+	"net/http"
+	"io"
+
+	"github.com/superfly/litefs"
+)
+
+
+// A simple Leaser which uses a provided URL for the primary
+type Leaser struct {
+    primaryURL string
+    id string
+    primaryID string
+}
+
+func NewLeaser(primaryURL string, id string) *Leaser {
+    return &Leaser{
+        primaryURL: primaryURL,
+        id: id,
+        primaryID: "",
+    }
+}
+
+func (l *Leaser) Close() (err error) { return nil }
+
+func (l *Leaser) AdvertiseURL() string { return "" }
+
+func (l *Leaser) Acquire(ctx context.Context) (litefs.Lease, error) {
+    // Query the primary's instance/id endpoint
+    resp, err := http.Get("http://localhost:20101/instance/id");
+    if err != nil {
+        log.Printf("Failed to reach primary for instance id")
+        return nil, litefs.ErrNoPrimary
+    }
+
+    defer resp.Body.Close()
+    primaryID, err := io.ReadAll(resp.Body)
+    l.primaryID = string(primaryID)
+
+    // Is somebody else the primary?
+    if !l.IsPrimary() {
+        return nil, litefs.ErrPrimaryExists
+    }
+
+    // I am the primary, return a lease
+    return Lease{
+        leaser: l,
+        renewedAt: time.Now(),
+    }, nil
+}
+
+func (l *Leaser) PrimaryURL(ctx context.Context) (string, error) {
+    if l.primaryID == "" {
+        return "", nil
+    } else {
+        return l.primaryURL, nil
+    }
+}
+
+func (l *Leaser) IsPrimary() bool {
+    return l.primaryID == l.id
+}
+
+type Lease struct {
+    leaser    *Leaser
+    renewedAt time.Time
+}
+
+func (l Lease) RenewedAt() time.Time {
+    return l.renewedAt
+}
+
+func (l Lease) TTL() time.Duration {
+    //TODO might be good to not have this be permanent?
+    return math.MaxInt64
+}
+
+func (l Lease) Renew(ctx context.Context) error {
+    l.renewedAt = time.Now()
+    return nil
+}
+
+func (l Lease) Close() error { return nil }

--- a/http/server.go
+++ b/http/server.go
@@ -122,6 +122,9 @@ func (s *Server) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	case "/metrics":
 		s.promHandler.ServeHTTP(w, r)
 
+    case "/instance/id":
+        io.WriteString(w, s.store.ID())
+
 	case "/stream":
 		switch r.Method {
 		case http.MethodPost:

--- a/litefs.go
+++ b/litefs.go
@@ -284,3 +284,5 @@ func assert(condition bool, msg string) {
 		panic("assertion failed: " + msg)
 	}
 }
+
+

--- a/litefs.go
+++ b/litefs.go
@@ -284,5 +284,3 @@ func assert(condition bool, msg string) {
 		panic("assertion failed: " + msg)
 	}
 }
-
-

--- a/store.go
+++ b/store.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/superfly/ltx"
 	"golang.org/x/sync/errgroup"
+	"github.com/google/uuid"
 )
 
 // Store represents a collection of databases.
@@ -39,6 +40,9 @@ type Store struct {
 
 	// Callback to notify kernel of file changes.
 	Invalidator Invalidator
+
+    // Unique ID for this store
+	id string
 }
 
 // NewStore returns a new instance of Store.
@@ -51,6 +55,7 @@ func NewStore(path string) *Store {
 		dbsByName: make(map[string]*DB),
 
 		subscribers: make(map[*Subscriber]struct{}),
+		id: uuid.NewString(),
 	}
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 
@@ -59,6 +64,9 @@ func NewStore(path string) *Store {
 
 // Path returns underlying data directory.
 func (s *Store) Path() string { return s.path }
+
+// ID returns underlying unique Store id.
+func (s *Store) ID() string { return s.id }
 
 // DBDir returns the folder that stores a single database.
 func (s *Store) DBDir(id uint32) string {
@@ -435,7 +443,7 @@ func (s *Store) monitorAsReplica(ctx context.Context, primaryURL string) error {
 	posMap := s.PosMap()
 	st, err := s.Client.Stream(ctx, primaryURL, posMap)
 	if err != nil {
-		return fmt.Errorf("connect to primary: %s", err)
+		return fmt.Errorf("connect to primary: %s ('%s')", err, primaryURL)
 	}
 
 	for {

--- a/store.go
+++ b/store.go
@@ -42,7 +42,7 @@ type Store struct {
 	Invalidator Invalidator
 
     // Unique ID for this store
-	id string
+    id string
 }
 
 // NewStore returns a new instance of Store.


### PR DESCRIPTION
Fixes #37.

This implementation leverages the existing Leaser/Lease interfaces.
The primary node is able to discover the fact that it is the primary
 by hitting a new HTTP endpoints `<primary url>/instance/id` and seeing if the
 returned uuid matches the one it generated at startup.