### PR TITLE
Expose info

### DIFF
--- a/litefs.go
+++ b/litefs.go
@@ -101,6 +101,11 @@ func (p Pos) IsZero() bool {
 	return p == (Pos{})
 }
 
+// Format formats pos as zero-padded <txid><checksum>
+func (p Pos) Format() string {
+	return fmt.Sprintf("%016x/%016x", p.TXID, p.Chksum)
+}
+
 // FormatDBID formats id as a 16-character hex string.
 func FormatDBID(id uint32) string {
 	return fmt.Sprintf("%08x", id)


### PR DESCRIPTION
Fixes #42, #43.

Both replicas and the primary now populate `<shadow_dir>/primary_url` and `<shadow_dir>/<db-id>/position`.  The position file contains the TXID and checksum formatted as `%016x/%016x`